### PR TITLE
Improve OpenAI key setup

### DIFF
--- a/marcia_streamlit_app.py
+++ b/marcia_streamlit_app.py
@@ -73,9 +73,8 @@ try:
 except ImportError:
     openai = None  # type: ignore
 
-api_key = (
-    os.getenv("OPENAI_API_KEY")
-    or (st.secrets["OPENAI_API_KEY"] if st and "OPENAI_API_KEY" in st.secrets else "")
+api_key = os.getenv("OPENAI_API_KEY") or (
+    st.secrets.get("OPENAI_API_KEY", "") if st else ""
 )
 OPENAI_AVAILABLE = bool(openai and api_key)
 if OPENAI_AVAILABLE:


### PR DESCRIPTION
## Summary
- simplify API key assignment logic
- use `st.secrets.get` for readability

## Testing
- `python -m py_compile marcia_streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6849cc0e0d5c832d87c360e474dcfa43