### PR TITLE
Move inline tests to dedicated module

### DIFF
--- a/marcia_streamlit_app.py
+++ b/marcia_streamlit_app.py
@@ -65,7 +65,10 @@ try:
 except ImportError:
     requests = None  # type: ignore
 
-from dateutil import parser as dateparser
+try:
+    from dateutil import parser as dateparser
+except Exception:
+    dateparser = None
 
 # OpenAI -------------------------------------------------------------------
 try:
@@ -119,6 +122,8 @@ def classify_article(title: str, body: str) -> str:
 
 
 def guess_date(s: str | None):
+    if not dateparser:
+        return None
     try:
         return dateparser.parse(str(s), dayfirst=False).date() if s else None
     except Exception:
@@ -329,8 +334,3 @@ if __name__ == "__main__":
     else:
         gui_main()
 
-# ── Tests -----------------------------------------------------------------
-if __name__ == "__test__":
-    assert classify_article("Opinion: Climate policy", "") == "opinion"
-    assert classify_article("Gobierno presenta nueva regulación", "") == "econpol"
-    assert classify_article("Se inaugura la COP30", "") == "coyuntural"

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1,0 +1,24 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from marcia_streamlit_app import classify_article
+
+
+class TestClassifyArticle(unittest.TestCase):
+    def test_opinion(self):
+        self.assertEqual(classify_article("Opinion: Climate policy", ""), "opinion")
+
+    def test_econpol(self):
+        self.assertEqual(
+            classify_article("Gobierno presenta nueva regulación", ""), "econpol"
+        )
+
+    def test_coyuntural(self):
+        self.assertEqual(classify_article("Se inaugura la COP30", ""), "coyuntural")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove inline test block from `marcia_streamlit_app.py`
- add `tests/test_classify.py` with unittest-based tests
- make `dateutil` import optional so test module imports without dependencies

## Testing
- `python -m unittest discover -s tests -v`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849ceea5dd0832db555ac9a50514a1e